### PR TITLE
議事録生成コンポーネントのTypeScriptエラー修正

### DIFF
--- a/packages/webapp/src/components/minutesContainer.tsx
+++ b/packages/webapp/src/components/minutesContainer.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Container,
   FormField,
+  Header,
   SpaceBetween,
   SelectProps,
   Textarea,
@@ -93,7 +94,13 @@ const MinutesContainer: React.FC<Props> = (props) => {
 
   return (
     <SpaceBetween size="l">
-      <Container header={{ variant: 'h3', children: '文字起こしデータ入力' }}>
+      <Container
+        header={
+          <Header variant="h3">
+            文字起こしデータ入力
+          </Header>
+        }
+      >
         <FormField label="文字起こしデータを入力してください">
           <Textarea
             value={transcriptText}
@@ -112,7 +119,13 @@ const MinutesContainer: React.FC<Props> = (props) => {
         </Box>
       </Container>
 
-      <Container header={{ variant: 'h3', children: '生成された議事録' }}>
+      <Container
+        header={
+          <Header variant="h3">
+            生成された議事録
+          </Header>
+        }
+      >
         <Box
           padding="l"
           variant="p"


### PR DESCRIPTION
# 議事録生成コンポーネントのTypeScriptエラー修正

## 修正内容
- minutesContainer.tsxで発生していたTypeScriptエラーを修正
- Container componentのheader属性の指定方法を修正（objectからReactElementへ変更）
- 必要なHeaderコンポーネントをimport

## エラー内容
以下のTypeScriptエラーが発生していました：
```
src/components/minutesContainer.tsx(96,28): error TS2353: Object literal may only specify known properties, and 'variant' does not exist in type 'ReactElement<any, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal'.
src/components/minutesContainer.tsx(115,28): error TS2353: Object literal may only specify known properties, and 'variant' does not exist in type 'ReactElement<any, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal'.
```

## 修正前
```typescript
<Container header={{ variant: 'h3', children: '文字起こしデータ入力' }}>
```

## 修正後
```typescript
<Container
  header={
    <Header variant="h3">
      文字起こしデータ入力
    </Header>
  }
>
```

この修正によって、Webappのビルドが正常に完了するようになりました。