### PR TITLE
モデルをClaude 3.5 Haikuに更新

### DIFF
--- a/packages/webapp/src/hooks/useBedrock.ts
+++ b/packages/webapp/src/hooks/useBedrock.ts
@@ -40,7 +40,7 @@ const useBedrock = () => {
       const response:InvokeModelWithResponseStreamCommandOutput = await bedrockClient.send(new InvokeModelWithResponseStreamCommand({
         body: body,
         contentType: "application/json",
-        modelId: "anthropic.claude-instant-v1"
+        modelId: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
       }))
   
       return response


### PR DESCRIPTION
Amazon Bedrockで使用するモデルをanthropicのClaude Instant V1からClaude 3.5 Haikuに更新しました。

## 変更内容
- useBedrock.tsファイル内のmodelIdを'anthropic.claude-instant-v1'から'us.anthropic.claude-3-5-haiku-20241022-v1:0'に変更